### PR TITLE
Feature/sa 43 auth

### DIFF
--- a/ShikiApp.xcodeproj/project.pbxproj
+++ b/ShikiApp.xcodeproj/project.pbxproj
@@ -68,6 +68,8 @@
 		3A19C06A298B75B40073D472 /* String+toDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C069298B75B40073D472 /* String+toDate.swift */; };
 		3A19C074298D75670073D472 /* UIImageViewAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C073298D75670073D472 /* UIImageViewAsync.swift */; };
 		3A19C076298FECC70073D472 /* String+extractURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C075298FECC70073D472 /* String+extractURLs.swift */; };
+		3A19C07A29941B890073D472 /* OAuth2Credential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C07929941B890073D472 /* OAuth2Credential.swift */; };
+		3A19C07C29941B990073D472 /* OAuth2Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C07B29941B990073D472 /* OAuth2Request.swift */; };
 		3A19C084299A38E50073D472 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C083299A38E50073D472 /* KeychainManager.swift */; };
 		3A1A09692985400900846058 /* NewsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09602985400900846058 /* NewsDetailViewController.swift */; };
 		3A1A096A2985400900846058 /* NewsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09612985400900846058 /* NewsDetailView.swift */; };
@@ -200,6 +202,8 @@
 		3A19C069298B75B40073D472 /* String+toDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+toDate.swift"; sourceTree = "<group>"; };
 		3A19C073298D75670073D472 /* UIImageViewAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewAsync.swift; sourceTree = "<group>"; };
 		3A19C075298FECC70073D472 /* String+extractURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extractURLs.swift"; sourceTree = "<group>"; };
+		3A19C07929941B890073D472 /* OAuth2Credential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Credential.swift; sourceTree = "<group>"; };
+		3A19C07B29941B990073D472 /* OAuth2Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Request.swift; sourceTree = "<group>"; };
 		3A19C083299A38E50073D472 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		3A1A09602985400900846058 /* NewsDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailViewController.swift; sourceTree = "<group>"; };
 		3A1A09612985400900846058 /* NewsDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailView.swift; sourceTree = "<group>"; };
@@ -684,6 +688,8 @@
 				3A7E4DA02985496A00E7CA17 /* URLParameterEncoder.swift */,
 				3A7E4DA12985496A00E7CA17 /* JSONParameterEncoder.swift */,
 				3A7E4DA22985496A00E7CA17 /* EndPointType.swift */,
+				3A19C07929941B890073D472 /* OAuth2Credential.swift */,
+				3A19C07B29941B990073D472 /* OAuth2Request.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1068,6 +1074,7 @@
 				3AFAFEE3298028BA00949FE2 /* NewsfeedViewController+Extension.swift in Sources */,
 				3A05E299297E8EA500987CFF /* NewsfeedBuilder.swift in Sources */,
 				3A1A096D2985400900846058 /* NewsDetailBuilder.swift in Sources */,
+				3A19C07C29941B990073D472 /* OAuth2Request.swift in Sources */,
 				3A05E295297E696200987CFF /* NewsfeedPresenter.swift in Sources */,
 				3A7E4DA82985496A00E7CA17 /* URLParameterEncoder.swift in Sources */,
 				006031B9297BCA7B00CD9A16 /* MyListViewController.swift in Sources */,
@@ -1089,6 +1096,7 @@
 				3A19C066298B757D0073D472 /* Date+toString.swift in Sources */,
 				3A7E4D8A2985492C00E7CA17 /* AnimeRatesResponseDTO.swift in Sources */,
 				006031BB297BCA9600CD9A16 /* ProfileViewController.swift in Sources */,
+				3A19C07A29941B890073D472 /* OAuth2Credential.swift in Sources */,
 				16B08247298A22B300EB9061 /* RanobeApi.swift in Sources */,
 				3A7E4D8D2985492C00E7CA17 /* UserHistoryResponseDTO.swift in Sources */,
 				BA27FB5529964EF5007C3BEC /* CGSize+scaling.swift in Sources */,

--- a/ShikiApp.xcodeproj/project.pbxproj
+++ b/ShikiApp.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		3A19C06A298B75B40073D472 /* String+toDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C069298B75B40073D472 /* String+toDate.swift */; };
 		3A19C074298D75670073D472 /* UIImageViewAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C073298D75670073D472 /* UIImageViewAsync.swift */; };
 		3A19C076298FECC70073D472 /* String+extractURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C075298FECC70073D472 /* String+extractURLs.swift */; };
+		3A19C084299A38E50073D472 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C083299A38E50073D472 /* KeychainManager.swift */; };
 		3A1A09692985400900846058 /* NewsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09602985400900846058 /* NewsDetailViewController.swift */; };
 		3A1A096A2985400900846058 /* NewsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09612985400900846058 /* NewsDetailView.swift */; };
 		3A1A096C2985400900846058 /* AppCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09642985400900846058 /* AppCollectionViewCell.swift */; };
@@ -199,6 +200,7 @@
 		3A19C069298B75B40073D472 /* String+toDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+toDate.swift"; sourceTree = "<group>"; };
 		3A19C073298D75670073D472 /* UIImageViewAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewAsync.swift; sourceTree = "<group>"; };
 		3A19C075298FECC70073D472 /* String+extractURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extractURLs.swift"; sourceTree = "<group>"; };
+		3A19C083299A38E50073D472 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		3A1A09602985400900846058 /* NewsDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailViewController.swift; sourceTree = "<group>"; };
 		3A1A09612985400900846058 /* NewsDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailView.swift; sourceTree = "<group>"; };
 		3A1A09642985400900846058 /* AppCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				0010CAB52977FFBE00F8705B /* AppColor.swift */,
 				0010CAB72977FFDC00F8705B /* AppFont.swift */,
 				0010CADA29783E7400F8705B /* AppImage.swift */,
+				3A19C083299A38E50073D472 /* KeychainManager.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1080,6 +1083,7 @@
 				166FA78F29894406009C2712 /* MangaEnums.swift in Sources */,
 				006031AF2979B79400CD9A16 /* TabBarViewController.swift in Sources */,
 				3A7E4D902985492C00E7CA17 /* BansResponseDTO.swift in Sources */,
+				3A19C084299A38E50073D472 /* KeychainManager.swift in Sources */,
 				3A19C068298B75A80073D472 /* String+htmlToString.swift in Sources */,
 				3A7E4D8C2985492C00E7CA17 /* UnreadMessagesResponseDTO.swift in Sources */,
 				3A19C066298B757D0073D472 /* Date+toString.swift in Sources */,

--- a/ShikiApp.xcodeproj/project.pbxproj
+++ b/ShikiApp.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		3A19C06A298B75B40073D472 /* String+toDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C069298B75B40073D472 /* String+toDate.swift */; };
 		3A19C074298D75670073D472 /* UIImageViewAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C073298D75670073D472 /* UIImageViewAsync.swift */; };
 		3A19C076298FECC70073D472 /* String+extractURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C075298FECC70073D472 /* String+extractURLs.swift */; };
+		3A19C078299415AC0073D472 /* OAuth2Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C077299415AC0073D472 /* OAuth2Manager.swift */; };
 		3A19C07A29941B890073D472 /* OAuth2Credential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C07929941B890073D472 /* OAuth2Credential.swift */; };
 		3A19C07C29941B990073D472 /* OAuth2Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C07B29941B990073D472 /* OAuth2Request.swift */; };
 		3A19C084299A38E50073D472 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C083299A38E50073D472 /* KeychainManager.swift */; };
@@ -202,6 +203,7 @@
 		3A19C069298B75B40073D472 /* String+toDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+toDate.swift"; sourceTree = "<group>"; };
 		3A19C073298D75670073D472 /* UIImageViewAsync.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewAsync.swift; sourceTree = "<group>"; };
 		3A19C075298FECC70073D472 /* String+extractURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+extractURLs.swift"; sourceTree = "<group>"; };
+		3A19C077299415AC0073D472 /* OAuth2Manager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Manager.swift; sourceTree = "<group>"; };
 		3A19C07929941B890073D472 /* OAuth2Credential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Credential.swift; sourceTree = "<group>"; };
 		3A19C07B29941B990073D472 /* OAuth2Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Request.swift; sourceTree = "<group>"; };
 		3A19C083299A38E50073D472 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
@@ -688,6 +690,7 @@
 				3A7E4DA02985496A00E7CA17 /* URLParameterEncoder.swift */,
 				3A7E4DA12985496A00E7CA17 /* JSONParameterEncoder.swift */,
 				3A7E4DA22985496A00E7CA17 /* EndPointType.swift */,
+				3A19C077299415AC0073D472 /* OAuth2Manager.swift */,
 				3A19C07929941B890073D472 /* OAuth2Credential.swift */,
 				3A19C07B29941B990073D472 /* OAuth2Request.swift */,
 			);
@@ -1132,6 +1135,7 @@
 				006031B7297BCA6800CD9A16 /* SearchViewController.swift in Sources */,
 				3A7E4DA72985496A00E7CA17 /* Router.swift in Sources */,
 				BA27FB4D2995384E007C3BEC /* NewsDetailVideoContentView.swift in Sources */,
+				3A19C078299415AC0073D472 /* OAuth2Manager.swift in Sources */,
 				3A7E4D982985492C00E7CA17 /* TopicsResponseDTO.swift in Sources */,
 				3A7E4D872985492C00E7CA17 /* MessagesResponseDTO.swift in Sources */,
 				3A7E4D7F2985492C00E7CA17 /* ForumsResponseDTO.swift in Sources */,

--- a/ShikiApp.xcodeproj/project.pbxproj
+++ b/ShikiApp.xcodeproj/project.pbxproj
@@ -71,6 +71,7 @@
 		3A19C078299415AC0073D472 /* OAuth2Manager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C077299415AC0073D472 /* OAuth2Manager.swift */; };
 		3A19C07A29941B890073D472 /* OAuth2Credential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C07929941B890073D472 /* OAuth2Credential.swift */; };
 		3A19C07C29941B990073D472 /* OAuth2Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C07B29941B990073D472 /* OAuth2Request.swift */; };
+		3A19C08229995AB60073D472 /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C08129995AB60073D472 /* AuthManager.swift */; };
 		3A19C084299A38E50073D472 /* KeychainManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A19C083299A38E50073D472 /* KeychainManager.swift */; };
 		3A1A09692985400900846058 /* NewsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09602985400900846058 /* NewsDetailViewController.swift */; };
 		3A1A096A2985400900846058 /* NewsDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09612985400900846058 /* NewsDetailView.swift */; };
@@ -206,6 +207,7 @@
 		3A19C077299415AC0073D472 /* OAuth2Manager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Manager.swift; sourceTree = "<group>"; };
 		3A19C07929941B890073D472 /* OAuth2Credential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Credential.swift; sourceTree = "<group>"; };
 		3A19C07B29941B990073D472 /* OAuth2Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OAuth2Request.swift; sourceTree = "<group>"; };
+		3A19C08129995AB60073D472 /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		3A19C083299A38E50073D472 /* KeychainManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainManager.swift; sourceTree = "<group>"; };
 		3A1A09602985400900846058 /* NewsDetailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailViewController.swift; sourceTree = "<group>"; };
 		3A1A09612985400900846058 /* NewsDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailView.swift; sourceTree = "<group>"; };
@@ -607,6 +609,7 @@
 				3A7E4D5E2985492C00E7CA17 /* Forums */,
 				3A7E4D662985492C00E7CA17 /* Users */,
 				3A7E4D762985492C00E7CA17 /* Topics */,
+				3A19C08129995AB60073D472 /* AuthManager.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1072,6 +1075,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3A7E4D8E2985492C00E7CA17 /* ClubsResponseDTO.swift in Sources */,
+				3A19C08229995AB60073D472 /* AuthManager.swift in Sources */,
 				0010CABF297802A700F8705B /* UIView+addSubviews.swift in Sources */,
 				3A7E4D882985492C00E7CA17 /* UserFavoritesResponseDTO.swift in Sources */,
 				3AFAFEE3298028BA00949FE2 /* NewsfeedViewController+Extension.swift in Sources */,

--- a/ShikiApp/App/BusinessLogic/Network/AbstractRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/AbstractRequestFactory.swift
@@ -10,7 +10,7 @@ import Foundation
 // MARK: - Result
 
 enum Result<String> {
-    case success
+    case success(String)
     case failure(String)
 }
 
@@ -72,11 +72,11 @@ class AbstractRequestFactory<API: EndPointType>: AbstractRequestFactoryProtocol 
         }
     }
 
-    // MARK: - Private Funcions
+    // MARK: - Private Functions
     
     private func handleNetworkResponse(_ response: HTTPURLResponse) -> Result<String> {
         switch response.statusCode {
-        case 200 ... 299: return .success
+        case 200 ... 299: return .success("success")
         case 401 ... 500: return .failure(NetworkLayerErrorMessages.authenticationError)
         case 501 ... 599: return .failure(NetworkLayerErrorMessages.badRequest)
         case 600: return .failure(NetworkLayerErrorMessages.outdated)

--- a/ShikiApp/App/BusinessLogic/Network/AbstractRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/AbstractRequestFactory.swift
@@ -72,11 +72,11 @@ class AbstractRequestFactory<API: EndPointType>: AbstractRequestFactoryProtocol 
         }
     }
 
-    // MARK: - Private Functions
+    // MARK: - Private functions
     
     private func handleNetworkResponse(_ response: HTTPURLResponse) -> Result<String> {
         switch response.statusCode {
-        case 200 ... 299: return .success("success")
+        case 200 ... 299: return .success(NetworkLayerErrorMessages.success)
         case 401 ... 500: return .failure(NetworkLayerErrorMessages.authenticationError)
         case 501 ... 599: return .failure(NetworkLayerErrorMessages.badRequest)
         case 600: return .failure(NetworkLayerErrorMessages.outdated)

--- a/ShikiApp/App/BusinessLogic/Network/ApiFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/ApiFactory.swift
@@ -30,7 +30,7 @@ final class ApiFactory: ApiFactoryProtocol {
     }
 
     private static var agent: String? {
-        guard let agent = ProcessInfo.processInfo.environment["USER_AGENT"] else { return nil }
+        guard let agent = Bundle.main.infoDictionary?["CFBundleName"] as? String else { return nil }
         return agent
     }
 

--- a/ShikiApp/App/BusinessLogic/Network/AuthManager.swift
+++ b/ShikiApp/App/BusinessLogic/Network/AuthManager.swift
@@ -1,0 +1,114 @@
+//
+//  AuthManager.swift
+//  ShikiApp
+//
+//  Created by Сергей Черных on 12.02.2023.
+//
+
+import Foundation
+
+protocol AuthManagerProtocol {
+    
+    func isAuth() -> Bool
+    func getToken() -> String?
+    func auth(handler: @escaping (Bool) -> Void)
+}
+
+final class AuthManager {
+
+    // MARK: - Properties
+    
+    static let share = AuthManager()
+
+    // MARK: - Private properties
+    
+    private let oAuth2Manager = OAuth2Manager()
+    private let keychain = KeychainManager()
+    private let bundleName = Bundle.main.infoDictionary?["CFBundleName"] as? String
+    private let account = "user"
+    private let request: OAuth2Request? = {
+        guard let clientId = ProcessInfo.processInfo.environment["clientId"],
+              let clientSecret = ProcessInfo.processInfo.environment["clientSecret"]
+        else { return nil }
+        return OAuth2Request(
+            authUrl: "\(Constants.Url.baseUrl)/oauth/authorize",
+            tokenUrl: "\(Constants.Url.baseUrl)/oauth/token",
+            clientId: clientId,
+            redirectUri: Constants.Url.redirectUri,
+            clientSecret: clientSecret,
+            scopes: ["user_rates", "comments", "topics"]
+        )
+    }()
+    private var credential: OAuth2Credential?
+
+    // MARK: - Construction
+    
+    private init() {
+        guard let bundleName else { return }
+        self.credential = keychain.get(service: bundleName, account: account, type: OAuth2Credential.self)
+        if tokenIsNeedUpdate() { updateToken() }
+    }
+
+    // MARK: - Functions
+    
+    func isAuth() -> Bool {
+        if credential?.accessToken == nil { return false }
+        return true
+    }
+    
+    func getToken() -> String? {
+        if tokenIsNeedUpdate() { updateToken() }
+        return credential?.accessToken
+    }
+    
+    func auth(handler: @escaping (Bool) -> Void) {
+        guard let request else {
+            handler(false)
+            return
+        }
+        
+        oAuth2Manager.auth(with: request) { [self] result in
+            guard let result = result,
+            let bundleName
+            else {
+                handler(false)
+                return
+            }
+            self.credential = result
+            self.keychain.save(result, service: bundleName, account: account)
+            handler(true)
+        }
+    }
+    
+    func logOut() {
+        self.credential = nil
+        guard let bundleName else { return }
+        keychain.delete(service: bundleName, account: account)
+    }
+
+    // MARK: - Private functions
+    
+    private func updateToken() {
+        guard let refreshToken = credential?.refreshToken,
+            let request = request?.makeRefreshTokenURL(refreshToken: refreshToken)
+        else { return }
+        oAuth2Manager.requestToken(for: request) { [self] result in
+            guard let result = result,
+                  let bundleName = self.bundleName
+            else { return }
+            self.credential = result
+            self.keychain.delete(service: bundleName, account: self.account)
+            self.keychain.save(result, service: bundleName, account: self.account)
+        }
+    }
+    
+    private func tokenIsNeedUpdate() -> Bool {
+        guard let expire = credential?.expire else { return false }
+        let limit = Date.now.addingTimeInterval(300)
+        if expire < limit {
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/ShikiApp/App/Flows/Home/Newsfeed/Presenter/NewsfeedPresenter.swift
+++ b/ShikiApp/App/Flows/Home/Newsfeed/Presenter/NewsfeedPresenter.swift
@@ -10,6 +10,7 @@ import UIKit
 protocol NewsfeedViewInput: AnyObject {
     
     var models: [NewsModel] { get set }
+    var isAuth: Bool { get set }
     func reloadData()
     func insertRows(indexPath: [IndexPath])
     func showErrorBackground()
@@ -21,6 +22,8 @@ protocol NewsfeedViewOutput: AnyObject {
     func fetchData()
     func endOfTableReached()
     func updateData(completion: @escaping () -> Void)
+    func didPressedRightBarItem()
+    func isAuth() -> Bool
 }
 
 final class NewsfeedPresenter: NewsfeedViewOutput {
@@ -97,5 +100,22 @@ final class NewsfeedPresenter: NewsfeedViewOutput {
             self.viewInput?.reloadData()
             completion()
         }
+    }
+    
+    func didPressedRightBarItem() {
+        if isAuth() {
+            AuthManager.share.logOut()
+            viewInput?.isAuth = false
+        } else {
+            AuthManager.share.auth { [weak self] result in
+                DispatchQueue.main.async {
+                    self?.viewInput?.isAuth = result
+                }
+            }
+        }
+    }
+    
+    func isAuth() -> Bool {
+        AuthManager.share.isAuth()
     }
 }

--- a/ShikiApp/App/Flows/Home/Newsfeed/Presenter/NewsfeedPresenter.swift
+++ b/ShikiApp/App/Flows/Home/Newsfeed/Presenter/NewsfeedPresenter.swift
@@ -87,7 +87,6 @@ final class NewsfeedPresenter: NewsfeedViewOutput {
             self.newsList.append(contentsOf: self.dataPortion)
             self.viewInput?.models.append(contentsOf: self.modelFactory.makeModels(from: self.dataPortion))
             self.viewInput?.insertRows(indexPath: indexPaths)
-            self.viewInput?.reloadData()
         }
     }
     

--- a/ShikiApp/App/Flows/Home/Newsfeed/View/NewsfeedTableViewCell.swift
+++ b/ShikiApp/App/Flows/Home/Newsfeed/View/NewsfeedTableViewCell.swift
@@ -85,6 +85,7 @@ class NewsfeedTableViewCell: UITableViewCell {
     
     private func configureUI() {
         self.selectedBackgroundView = accentBackgroundView
+        self.contentView.backgroundColor = AppColor.backgroundMain
         self.addSubviews([newsImageView, dateLabel, titleLabel, subtitleLabel, strokeView])
         setupConstraints()
     }

--- a/ShikiApp/App/Flows/Home/Newsfeed/View/NewsfeedViewController.swift
+++ b/ShikiApp/App/Flows/Home/Newsfeed/View/NewsfeedViewController.swift
@@ -13,6 +13,11 @@ class NewsfeedViewController: (UIViewController & NewsfeedViewInput) {
     
     let presenter: NewsfeedViewOutput
     var models: [NewsModel] = []
+    var isAuth: Bool {
+        didSet {
+            configureRightBarItem()
+        }
+    }
 
     // MARK: - Private Properties
     
@@ -63,6 +68,7 @@ class NewsfeedViewController: (UIViewController & NewsfeedViewInput) {
     
     init(presenter: NewsfeedViewOutput) {
         self.presenter = presenter
+        self.isAuth = presenter.isAuth()
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -111,8 +117,23 @@ class NewsfeedViewController: (UIViewController & NewsfeedViewInput) {
             self?.tableView.refreshControl?.endRefreshing()
         }
     }
+    
+    @objc func didPressedRightBarItem() {
+        presenter.didPressedRightBarItem()
+    }
 
     // MARK: - Private functions
+    
+    private func configureRightBarItem() {
+        let loginItem = UIBarButtonItem(
+            image: isAuth ? AppImage.NavigationsBarIcons.logout : AppImage.NavigationsBarIcons.login,
+            style: .plain,
+            target: self,
+            action: #selector(didPressedRightBarItem)
+        )
+        loginItem.tintColor = AppColor.textMain
+        navigationItem.rightBarButtonItem = loginItem
+    }
     
     private func setupViews() {
         backgroundView.addSubviews([backgroundErrorImageView, backgroundErrorLabel, activityIndicator])
@@ -128,6 +149,7 @@ class NewsfeedViewController: (UIViewController & NewsfeedViewInput) {
         tableView.prefetchDataSource = self
         setupPullToRefresh()
         activityIndicator.startAnimating()
+        configureRightBarItem()
     }
     
     private func setupPullToRefresh() {

--- a/ShikiApp/Core/Helpers/KeychainManager.swift
+++ b/ShikiApp/Core/Helpers/KeychainManager.swift
@@ -1,0 +1,71 @@
+//
+//  KeychainManager.swift
+//  ShikiApp
+//
+//  Created by Сергей Черных on 13.02.2023.
+//
+
+import Foundation
+import Security
+
+final class KeychainManager {
+
+    // MARK: - Functions
+    
+    func save<T: Codable>(_ item: T, service: String, account: String) {
+        do {
+            let data = try JSONEncoder().encode(item)
+            save(data, service: service, account: account)
+        } catch {
+            assertionFailure("Fail to encode item for keychain: \(error)")
+        }
+    }
+    
+    func get<T: Codable>(service: String, account: String, type: T.Type) -> T? {
+        guard let data = self.get(service: service, account: account) else { return nil }
+        do {
+            let item = try JSONDecoder().decode(type, from: data)
+            return item
+        } catch {
+            assertionFailure("Fail to decode item for keychain: \(error)")
+            return nil
+        }
+    }
+    
+    func delete(service: String, account: String) {
+        let query = [
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecClass: kSecClassGenericPassword
+        ] as CFDictionary
+        SecItemDelete(query)
+    }
+
+    // MARK: - Private functions
+    
+    private func get(service: String, account: String) -> Data? {
+        let query = [
+            kSecAttrService: service,
+            kSecAttrAccount: account,
+            kSecClass: kSecClassGenericPassword,
+            kSecReturnData: true
+        ] as CFDictionary
+        var result: AnyObject?
+        SecItemCopyMatching(query, &result)
+        return (result as? Data)
+    }
+    
+    private func save(_ data: Data, service: String, account: String) {
+        let query = [
+            kSecValueData: data,
+            kSecClass: kSecClassGenericPassword,
+            kSecAttrService: service,
+            kSecAttrAccount: account
+        ] as CFDictionary
+        let status = SecItemAdd(query, nil)
+        
+        if status != errSecSuccess {
+            assertionFailure("KeychainManager -> Error: \(status)")
+        }
+    }
+}

--- a/ShikiApp/Core/Network/HttpConstants.swift
+++ b/ShikiApp/Core/Network/HttpConstants.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+
 struct HttpConstants {
     
     static let contentType = "Content-Type"

--- a/ShikiApp/Core/Network/OAuth2Credential.swift
+++ b/ShikiApp/Core/Network/OAuth2Credential.swift
@@ -1,0 +1,41 @@
+//
+//  OAuth2Credential.swift
+//  ShikiApp
+//
+//  Created by Сергей Черных on 08.02.2023.
+//
+
+import Foundation
+
+struct OAuth2Credential: Codable {
+    
+    let accessToken: String
+    let tokenType: String?
+    let refreshToken: String?
+    let scope: String?
+    let expiresIn: Int?
+    var expire: Date?
+    
+    enum CodingKeys: String, CodingKey {
+        case accessToken
+        case tokenType
+        case refreshToken
+        case scope
+        case expiresIn
+        case expire
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.accessToken = try container.decode(String.self, forKey: .accessToken)
+        self.tokenType = try container.decodeIfPresent(String.self, forKey: .tokenType)
+        self.refreshToken = try container.decodeIfPresent(String.self, forKey: .refreshToken)
+        self.scope = try container.decodeIfPresent(String.self, forKey: .scope)
+        self.expiresIn = try container.decodeIfPresent(Int.self, forKey: .expiresIn)
+        self.expire = try container.decodeIfPresent(Date.self, forKey: .expire)
+        if expire == nil {
+            guard let expiresIn else { return }
+            self.expire = Date.now.addingTimeInterval(Double(expiresIn))
+        }
+    }
+}

--- a/ShikiApp/Core/Network/OAuth2Manager.swift
+++ b/ShikiApp/Core/Network/OAuth2Manager.swift
@@ -1,0 +1,88 @@
+//
+//  OAuth2Manager.swift
+//  ShikiApp
+//
+//  Created by Сергей Черных on 08.02.2023.
+//
+
+import AuthenticationServices
+
+final class OAuth2Manager: NSObject {
+
+    // MARK: - Private properties
+
+    private var credential: OAuth2Credential?
+
+    // MARK: - Functions
+    
+    func auth(with request: OAuth2Request, completion: @escaping (OAuth2Credential?) -> Void) {
+        guard let components = URLComponents(string: request.redirectUri),
+              let callbackScheme = components.scheme,
+              let requestUrl = request.makeAuthURL()
+        else { return }
+        
+        self.requestAuth(with: requestUrl, scheme: callbackScheme) { result in
+            switch result {
+            case .failure:
+                return
+            case .success(let code):
+                guard let tokenUrl = request.makeTokenURL(code: code) else { return }
+                self.requestToken(for: tokenUrl) { credential in
+                   completion(credential)
+                }
+            }
+        }
+    }
+    
+    func requestToken(for url: URL, completion: @escaping (OAuth2Credential?) -> Void) {
+        var request =  URLRequest(url: url)
+        request.httpMethod = HTTPMethod.post.rawValue
+        request.addValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.addValue("application/json", forHTTPHeaderField: "Accept")
+        
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        
+        let queue = OperationQueue()
+        queue.qualityOfService = .utility
+        
+        let session = URLSession(configuration: .default, delegate: nil, delegateQueue: queue)
+        
+        let task = session.dataTask(with: request) { data, response, _  in
+            guard let httpResponse = response as? HTTPURLResponse,
+                  200..<300 ~= httpResponse.statusCode,
+                  let data = data
+            else { return }
+            completion(try? decoder.decode(OAuth2Credential.self, from: data))
+        }
+        task.resume()
+    }
+
+    // MARK: - Private functions
+    
+    private func requestAuth(with url: URL?, scheme: String, completion: @escaping (Result<String>) -> Void) {
+        guard let url = url else { return }
+        let session = ASWebAuthenticationSession(url: url, callbackURLScheme: scheme) { callbackURL, error in
+            if let error = error {
+                completion(.failure(error.localizedDescription))
+                return
+            }
+            guard let url = callbackURL else { return }
+            if let token = URLComponents(string: url.absoluteString)?
+                .queryItems?.first(where: { $0.name == "code" })?.value {
+                completion(.success(token))
+            } else {
+                completion(.failure("tokenNotFound"))
+            }
+        }
+        session.prefersEphemeralWebBrowserSession = true
+        session.presentationContextProvider = self
+        session.start()
+    }
+}
+
+extension OAuth2Manager: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return ASPresentationAnchor()
+    }
+}

--- a/ShikiApp/Core/Network/OAuth2Request.swift
+++ b/ShikiApp/Core/Network/OAuth2Request.swift
@@ -1,0 +1,59 @@
+//
+//  OAuth2Request.swift
+//  ShikiApp
+//
+//  Created by Сергей Черных on 08.02.2023.
+//
+
+import Foundation
+
+struct OAuth2Request {
+    
+    let authUrl: String
+    let tokenUrl: String
+    let clientId: String
+    let redirectUri: String
+    let clientSecret: String
+    let scopes: [String]
+}
+
+extension OAuth2Request {
+    
+    func makeAuthURL() -> URL? {
+        let queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "redirect_uri", value: redirectUri),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: scopes.joined(separator: "+"))
+        ]
+        var components = URLComponents(string: authUrl)
+        components?.queryItems = queryItems
+        return components?.url
+    }
+    
+    func makeTokenURL(code: String) -> URL? {
+        let queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "client_secret", value: clientSecret),
+            URLQueryItem(name: "code", value: code),
+            URLQueryItem(name: "grant_type", value: "authorization_code"),
+            URLQueryItem(name: "redirect_uri", value: redirectUri)
+        ]
+        var components = URLComponents(string: tokenUrl)
+        components?.queryItems = queryItems
+        return components?.url
+    }
+    
+    func makeRefreshTokenURL(refreshToken: String) -> URL? {
+        let queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "client_secret", value: clientSecret),
+            URLQueryItem(name: "refresh_token", value: refreshToken),
+            URLQueryItem(name: "grant_type", value: "refresh_token"),
+            URLQueryItem(name: "redirect_uri", value: redirectUri)
+        ]
+        var components = URLComponents(string: tokenUrl)
+        components?.queryItems = queryItems
+        return components?.url
+    }
+}

--- a/ShikiApp/Resources/Constants.swift
+++ b/ShikiApp/Resources/Constants.swift
@@ -15,10 +15,7 @@ struct Constants {
         static let baseUrl = Bundle.main.object(forInfoDictionaryKey: HttpConstants.baseUrl) as? String ?? ""
         static let baseYoutubeUrl = "https://www.youtube.com/embed/"
         static let deeplinkYoutubeUrl = "https://www.youtube.com/watch?v="
-    }
-    
-    enum Keys {
-        
+		static let redirectUri = "ShikiApp://callback"
     }
     
     enum Insets {


### PR DESCRIPTION
добавил авторизацию пользователя, с сохранением данных в keychain, обновлением токена если он протух.
добавил авторизацию на экран новостной ленты.
Не сделано: сетевой слой должен при отправке запроса запрашивать токен у менеджера а не из окружения