### PR TITLE
Feature/SA-47 Add pagination to search screen

### DIFF
--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/SearchPresenter.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/SearchPresenter.swift
@@ -95,13 +95,14 @@ final class SearchPresenter: SearchViewOutput {
     // MARK: - Private functions
 
     private func refreshView() {
-        switch page {
-        case 0:
-            viewInput?.models.removeAll()
-        case 1:
-            viewInput?.models = SearchModelFactory().makeModels(from: entityList)
-        default:
-            viewInput?.models.append(contentsOf: SearchModelFactory().makeModels(from: entityList))
+        if !entityList.isEmpty {
+            if page > 1 {
+                viewInput?.models.append(contentsOf: SearchModelFactory().makeModels(from: entityList))
+            } else {
+                viewInput?.models = SearchModelFactory().makeModels(from: entityList)
+            }
+        } else {
+            if page == 0 { viewInput?.models.removeAll() }
         }
         viewInput?.tableHeader = buildHeader()
     }
@@ -113,8 +114,8 @@ final class SearchPresenter: SearchViewOutput {
         if page == 0 && entityList.isEmpty {
             return ""
         }
-        if (1 ..< pageSize).contains(entityList.count) {
-            return "\(Constants.SearchHeader.exactResult) \(entityList.count + pageSize * (page - 1))"
+        if (0 ..< pageSize).contains(entityList.count) {
+            return "\(Constants.SearchHeader.exactResult) \(viewInput?.models.count ?? 0)"
         }
         return "\(Constants.SearchHeader.approximateResult)"
     }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/Controls/ControlConstants.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/Controls/ControlConstants.swift
@@ -10,10 +10,8 @@ import UIKit
 
 struct ControlConstants {
     
-    static let sliderImage: UIImage = {
-        UIImage(systemName: "slider.horizontal.3") ?? UIImage()}()
+    static let sliderImage: UIImage = AppImage.NavigationsBarIcons.options
     static let searchPlaceHolder = "Аниме, манга, ранобэ"
-
 
     enum Properties {
         static let cellHeight: CGFloat = 112

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/Controls/ControlConstants.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/Controls/ControlConstants.swift
@@ -11,7 +11,7 @@ import UIKit
 struct ControlConstants {
     
     static let sliderImage: UIImage = AppImage.NavigationsBarIcons.options
-    static let searchPlaceHolder = "Аниме, манга, ранобэ"
+    static let searchPlaceHolder = "Поиск по названию"
 
     enum Properties {
         static let cellHeight: CGFloat = 112

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchTableCell.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchTableCell.swift
@@ -11,9 +11,8 @@ class SearchTableCell: UITableViewCell {
 
     // MARK: - Private properties
     
-    private let lineWidth: CGFloat = 1
+    private let lineHeight: CGFloat = 1
     private let maxTitleLines = 3
-    private let imageWidth: CGFloat = 88
     private let scoreWidth: CGFloat = 39
     private let scoreHeight: CGFloat = 24
     private let scoreTopInset: CGFloat = 8
@@ -114,7 +113,7 @@ class SearchTableCell: UITableViewCell {
         NSLayoutConstraint.activate([
             contentImageView.topAnchor.constraint(equalTo: topAnchor),
             contentImageView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            contentImageView.widthAnchor.constraint(equalToConstant: imageWidth),
+            contentImageView.widthAnchor.constraint(equalToConstant: Constants.Insets.coverWidth),
             contentImageView.bottomAnchor.constraint(equalTo: bottomAnchor),
             scoreLabel.leadingAnchor.constraint(equalTo: contentImageView.leadingAnchor, constant: leading),
             scoreLabel.widthAnchor.constraint(equalToConstant: scoreWidth),
@@ -132,7 +131,7 @@ class SearchTableCell: UITableViewCell {
             strokeView.leadingAnchor.constraint(equalTo: contentImageView.trailingAnchor, constant: leading),
             strokeView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: trailing),
             strokeView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            strokeView.heightAnchor.constraint(equalToConstant: lineWidth)
+            strokeView.heightAnchor.constraint(equalToConstant: lineHeight)
         ])
     }
 }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchTableCell.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchTableCell.swift
@@ -12,6 +12,7 @@ class SearchTableCell: UITableViewCell {
     // MARK: - Private properties
     
     private let lineWidth: CGFloat = 1
+    private let maxTitleLines = 3
     private let imageWidth: CGFloat = 88
     private let scoreWidth: CGFloat = 39
     private let scoreHeight: CGFloat = 24
@@ -47,8 +48,8 @@ class SearchTableCell: UITableViewCell {
         let label = AppLabel(alignment: .left, fontSize: AppFont.openSansFont(ofSize: 16, weight: .bold))
         label.textColor = AppColor.textMain
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.lineBreakMode = .byWordWrapping
-        label.numberOfLines = 0
+        label.lineBreakMode = .byTruncatingTail
+        label.numberOfLines = 3
         return label
     }()
     

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchView.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchView.swift
@@ -226,15 +226,22 @@ class SearchView: UIView {
             tableView.leadingAnchor.constraint(equalTo: leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
             tableView.bottomAnchor.constraint(equalTo: bottomAnchor),
-            backgroundImageView.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
-            backgroundImageView.centerYAnchor.constraint(equalTo: tableView.centerYAnchor),
+            mainBackgroundView.topAnchor.constraint(
+                equalTo: topAnchor,
+                constant: ControlConstants.Properties.tableTop
+            ),
+            mainBackgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            mainBackgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            mainBackgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            backgroundImageView.centerXAnchor.constraint(equalTo: mainBackgroundView.centerXAnchor),
+            backgroundImageView.centerYAnchor.constraint(equalTo: mainBackgroundView.centerYAnchor),
             backgroundImageView.widthAnchor.constraint(
                 equalToConstant: ControlConstants.Properties.backgroundImageSize
             ),
             backgroundImageView.heightAnchor.constraint(
                 equalToConstant: ControlConstants.Properties.backgroundImageSize
             ),
-            backgroundLabel.centerXAnchor.constraint(equalTo: tableView.centerXAnchor),
+            backgroundLabel.centerXAnchor.constraint(equalTo: mainBackgroundView.centerXAnchor),
             backgroundLabel.topAnchor.constraint(
                 equalTo: backgroundImageView.bottomAnchor, constant: ControlConstants.Properties.backgroundLabelInset
             )

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchView.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchView.swift
@@ -27,7 +27,6 @@ class SearchView: UIView {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorStyle = .none
-//        tableView.allowsSelection = true
         return tableView
     }()
     
@@ -47,6 +46,7 @@ class SearchView: UIView {
         textField.layer.masksToBounds = true
         textField.keyboardType = .default
         textField.keyboardAppearance = .light
+        textField.autocorrectionType = .no
         return textField
     }()
     

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchView.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchView.swift
@@ -27,6 +27,7 @@ class SearchView: UIView {
         let tableView = UITableView()
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.separatorStyle = .none
+//        tableView.allowsSelection = true
         return tableView
     }()
     

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController+Extensions.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController+Extensions.swift
@@ -33,7 +33,7 @@ extension SearchViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         let entity = models[indexPath.row]
-        self.presenter.viewDidSelectNews(entity: entity)
+        self.presenter.viewDidSelectEntity(entity: entity)
     }
 }
 
@@ -70,5 +70,16 @@ extension SearchViewController: UITextFieldDelegate {
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
         textField.resignFirstResponder()
         return true
+    }
+}
+
+// MARK: - UITableViewDataSourcePrefetching
+
+extension SearchViewController: UITableViewDataSourcePrefetching {
+    func tableView(_ tableView: UITableView, prefetchRowsAt indexPaths: [IndexPath]) {
+        guard let maxRow = indexPaths.map({ $0.row }).max() else { return }
+        if maxRow > models.count - 3 {
+            presenter.endOfTableReached()
+        }
     }
 }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController.swift
@@ -37,9 +37,7 @@ final class SearchViewController: UIViewController, SearchViewInput {
     init(presenter: SearchViewOutput) {
         self.presenter = presenter
         super.init(nibName: nil, bundle: nil)
-        searchView.searchTextField.delegate = self
-        searchView.tableView.delegate = self
-        searchView.tableView.dataSource = self
+
     }
 
     required init?(coder _: NSCoder) {
@@ -54,16 +52,13 @@ final class SearchViewController: UIViewController, SearchViewInput {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        searchView.delegate = self
-        applySearch()
-        addTapGestureToHideKeyboard()
-        presenter.fetchData()
-        searchView.searchTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+        configureOnViewDidLoad()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
+        presenter.fetchData()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
@@ -94,8 +89,20 @@ final class SearchViewController: UIViewController, SearchViewInput {
 
     // MARK: - Private functions
 
+    private func configureOnViewDidLoad() {
+        searchView.searchTextField.delegate = self
+        searchView.tableView.delegate = self
+        searchView.tableView.dataSource = self
+        searchView.tableView.prefetchDataSource = self
+        searchView.delegate = self
+        applySearch()
+        addTapGestureToHideKeyboard()
+        searchView.searchTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
+    }
+
     private func addTapGestureToHideKeyboard() {
         let tapGesture = UITapGestureRecognizer(target: searchView, action: #selector(searchView.endEditing))
+        tapGesture.cancelsTouchesInView = false
         searchView.addGestureRecognizer(tapGesture)
     }
     

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController.swift
@@ -63,11 +63,11 @@ final class SearchViewController: UIViewController, SearchViewInput {
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        navigationController?.setNavigationBarHidden(false, animated: false)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
         super.viewDidDisappear(animated)
-        navigationController?.setNavigationBarHidden(false, animated: false)
     }
 
     // MARK: - Functions

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/View/SearchViewController.swift
@@ -53,12 +53,12 @@ final class SearchViewController: UIViewController, SearchViewInput {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureOnViewDidLoad()
+        presenter.fetchData()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: false)
-        presenter.fetchData()
     }
     
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
На экране поиска:
добавил загрузку страниц при скроллинге таблицы результатов
поменял иконку на кнопке Фильтры
пофиксил баг: не отрабатывал тап на ячейке таблицы для вызова экрана детальной информации. (мешал gesture recognizer)
ограничил кол-во строк в  Title  не более 3
поменял привязку фонового image: фоновый вью таблицы по границам таблицы, фоновый image по центру фонового вью и lable с сообщением об ошибке под ним