### PR TITLE
Feature/SA-56 Change filters counting

### DIFF
--- a/ShikiApp/App/BusinessLogic/Network/Mangas/MangaListFilters.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Mangas/MangaListFilters.swift
@@ -13,9 +13,19 @@ import Foundation
 typealias MangaListFilters = ListFilters<MangaContentKind, MangaContentStatus>
 
 struct ListFilters<K, S> {
+    
     var kind: K?
     var status: S?
     var season: String?
     var score: Int?
     var genre: [Int]?
+    lazy var filtersCount: Int = {
+        var counter = 0
+        if let kind { counter += 1 }
+        if let status { counter += 1 }
+        if let score { counter += 1 }
+        if let genre { counter += genre.count }
+        if let season { counter += 1 + season.filter {$0 == Constants.FilterParameters.delimiter}.count }
+        return counter
+    }()
 }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/AnimeProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/AnimeProvider.swift
@@ -26,11 +26,11 @@ final class AnimeProvider: ContentProviderProtocol {
 
     func setFilters(filters: Any?) -> Int {
         self.filters = filters as? AnimeListFilters
-        return getFiltersCount()
+        return self.filters?.filtersCount ?? 0
     }
 
     func getFiltersCounter() -> Int {
-        return getFiltersCount()
+        return self.filters?.filtersCount ?? 0
     }
     
     func getFilters() -> ListFilters<ContentKind, ContentStatus>? { filters }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentProviderProtocol.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentProviderProtocol.swift
@@ -29,19 +29,3 @@ protocol ContentProviderProtocol {
         _ error: String?
     ) -> Void)
 }
-
-extension ContentProviderProtocol {
-
-    // MARK: - Functions
-
-    func getFiltersCount() -> Int {
-        guard var filters else { return 0 }
-        if let genres = filters.genre, genres.isEmpty { filters.genre = nil }
-        if (filters.season ?? "").isEmpty { filters.season = nil }
-        return Mirror(reflecting: filters)
-            .children
-            .filter({ $0.label != nil })
-            .filter({Mirror(reflecting: $0.value).children.count > 0})
-            .count
-    }
-}

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/MangaProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/MangaProvider.swift
@@ -26,11 +26,11 @@ final class MangaProvider: ContentProviderProtocol {
 
     func setFilters(filters: Any?) -> Int {
         self.filters = filters as? MangaListFilters
-        return getFiltersCount()
+        return self.filters?.filtersCount ?? 0
     }
     
     func getFiltersCounter() -> Int {
-        return getFiltersCount()
+        return self.filters?.filtersCount ?? 0
     }
     
     func getFilters() -> ListFilters<ContentKind, ContentStatus>? { filters }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RanobeProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RanobeProvider.swift
@@ -26,11 +26,11 @@ final class RanobeProvider: ContentProviderProtocol {
 
     func setFilters(filters: Any?) -> Int {
         self.filters = filters as? RanobeListFilters
-        return getFiltersCount()
+        return self.filters?.filtersCount ?? 0
     }
     
     func getFiltersCounter() -> Int {
-        return getFiltersCount()
+        return self.filters?.filtersCount ?? 0
     }
     
     func getFilters() -> ListFilters<RanobeContentKind, RanobeContentStatus>? { filters }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/SearchPresenter.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/SearchPresenter.swift
@@ -117,7 +117,7 @@ final class SearchPresenter: SearchViewOutput {
     }
     
     private func buildHeader() -> String {
-        if (searchString ?? "").isEmpty && providers[layer]?.getFiltersCount() ?? 0 == 0 {
+        if (searchString ?? "").isEmpty && providers[layer]?.getFiltersCounter() ?? 0 == 0 {
             return "\(Constants.SearchHeader.emptyStringResult) \(layer.rawValue.lowercased())"
         }
         if page == 0 && entityList.isEmpty {

--- a/ShikiApp/Resources/Constants.swift
+++ b/ShikiApp/Resources/Constants.swift
@@ -64,7 +64,11 @@ struct Constants {
     enum Dates {
         static let startYearForFilter = 1917
     }
-
+    
+    enum FilterParameters {
+        static let delimiter: Character = ","
+    }
+    
     enum SearchHeader {
         static let emptyStringResult = "Лучшие"
         static let exactResult = "Найдено:"


### PR DESCRIPTION
Изменил подсчет количества выбранных фильтров для отображения на кнопке "Фильтры" экрана поиска:
"оценка" добавляет к счетчику 1, если выбрана
"тип" добавляет к счетчику 1, если выбран
"статус" добавляет к счетчику 1, если выбран
"жанр" добавляет к счетчику кол-во выбранных жанров  (пока можно выбрать только 1)
"год с - по" добавляет к счетчику 1, если выбран хотя бы один год
"сезон " добавляет к счетчику кол-во выбранных сезонов (пока можно выбрать только 1)

