### PR TITLE
Feature/ SA-81 Add "censored" parameter  to content search engine

### DIFF
--- a/ShikiApp.xcodeproj/project.pbxproj
+++ b/ShikiApp.xcodeproj/project.pbxproj
@@ -117,6 +117,9 @@
 		16D49EA7298EF3540008CAA4 /* MangaProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D49EA6298EF3540008CAA4 /* MangaProvider.swift */; };
 		16D49EA9298EF5660008CAA4 /* RanobeProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D49EA8298EF5660008CAA4 /* RanobeProvider.swift */; };
 		16D49EAB298FC6260008CAA4 /* SearchTableCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D49EAA298FC6260008CAA4 /* SearchTableCell.swift */; };
+		16D6079429C1D41E00492879 /* ContentRestrictionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D6079329C1D41E00492879 /* ContentRestrictionsProvider.swift */; };
+		16D6079729C1D9BF00492879 /* Notification.Name.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D6079629C1D9BF00492879 /* Notification.Name.swift */; };
+		16D6079929C21E7400492879 /* RestrictionsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D6079829C21E7400492879 /* RestrictionsProvider.swift */; };
 		16F98B5729AA808A009ADBA0 /* Date+relativeYear.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F98B5629AA808A009ADBA0 /* Date+relativeYear.swift */; };
 		3A05E291297D606B00987CFF /* NewsfeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A05E290297D606B00987CFF /* NewsfeedViewController.swift */; };
 		3A05E293297D60B100987CFF /* NewsfeedTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A05E292297D60B100987CFF /* NewsfeedTableViewCell.swift */; };
@@ -137,10 +140,10 @@
 		3A1A096C2985400900846058 /* AppCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09642985400900846058 /* AppCollectionViewCell.swift */; };
 		3A1A096D2985400900846058 /* NewsDetailBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09662985400900846058 /* NewsDetailBuilder.swift */; };
 		3A1A096E2985400900846058 /* NewsDetailPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1A09682985400900846058 /* NewsDetailPresenter.swift */; };
+		3A200A6729B11FA8001719A4 /* Array+removeDuplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A200A6629B11FA8001719A4 /* Array+removeDuplicates.swift */; };
 		3A200A6A29B28061001719A4 /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3A200A6929B28061001719A4 /* Secret.xcconfig */; };
 		3A200A6B29B28061001719A4 /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3A200A6929B28061001719A4 /* Secret.xcconfig */; };
 		3A200A6C29B28061001719A4 /* Secret.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 3A200A6929B28061001719A4 /* Secret.xcconfig */; };
-		3A200A6729B11FA8001719A4 /* Array+removeDuplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A200A6629B11FA8001719A4 /* Array+removeDuplicates.swift */; };
 		3A275770297EFDD900EFD543 /* NewsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A27576F297EFDD900EFD543 /* NewsModel.swift */; };
 		3A7E4D7F2985492C00E7CA17 /* ForumsResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7E4D602985492C00E7CA17 /* ForumsResponseDTO.swift */; };
 		3A7E4D802985492C00E7CA17 /* ForumsRequestFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A7E4D612985492C00E7CA17 /* ForumsRequestFactory.swift */; };
@@ -326,6 +329,9 @@
 		16D49EA6298EF3540008CAA4 /* MangaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaProvider.swift; sourceTree = "<group>"; };
 		16D49EA8298EF5660008CAA4 /* RanobeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RanobeProvider.swift; sourceTree = "<group>"; };
 		16D49EAA298FC6260008CAA4 /* SearchTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableCell.swift; sourceTree = "<group>"; };
+		16D6079329C1D41E00492879 /* ContentRestrictionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRestrictionsProvider.swift; sourceTree = "<group>"; };
+		16D6079629C1D9BF00492879 /* Notification.Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.Name.swift; sourceTree = "<group>"; };
+		16D6079829C21E7400492879 /* RestrictionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictionsProvider.swift; sourceTree = "<group>"; };
 		16F98B5629AA808A009ADBA0 /* Date+relativeYear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+relativeYear.swift"; sourceTree = "<group>"; };
 		3A05E290297D606B00987CFF /* NewsfeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedViewController.swift; sourceTree = "<group>"; };
 		3A05E292297D60B100987CFF /* NewsfeedTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedTableViewCell.swift; sourceTree = "<group>"; };
@@ -346,8 +352,8 @@
 		3A1A09642985400900846058 /* AppCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCollectionViewCell.swift; sourceTree = "<group>"; };
 		3A1A09662985400900846058 /* NewsDetailBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailBuilder.swift; sourceTree = "<group>"; };
 		3A1A09682985400900846058 /* NewsDetailPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NewsDetailPresenter.swift; sourceTree = "<group>"; };
-		3A200A6929B28061001719A4 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		3A200A6629B11FA8001719A4 /* Array+removeDuplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+removeDuplicates.swift"; sourceTree = "<group>"; };
+		3A200A6929B28061001719A4 /* Secret.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secret.xcconfig; sourceTree = "<group>"; };
 		3A27576F297EFDD900EFD543 /* NewsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsModel.swift; sourceTree = "<group>"; };
 		3A7E4D602985492C00E7CA17 /* ForumsResponseDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForumsResponseDTO.swift; sourceTree = "<group>"; };
 		3A7E4D612985492C00E7CA17 /* ForumsRequestFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForumsRequestFactory.swift; sourceTree = "<group>"; };
@@ -465,6 +471,7 @@
 		0010CAB92978018C00F8705B /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				16D6079529C1D99200492879 /* Notification.Name */,
 				3A200A6829B11FDB001719A4 /* Array */,
 				006240F12997AF6400498D51 /* UIApplication */,
 				BA27FB5629964EFC007C3BEC /* CGSize */,
@@ -856,6 +863,8 @@
 				16D49EA6298EF3540008CAA4 /* MangaProvider.swift */,
 				16D49EA8298EF5660008CAA4 /* RanobeProvider.swift */,
 				16092D06299B929A00CEE770 /* ContentProviderProtocol.swift */,
+				16D6079829C21E7400492879 /* RestrictionsProvider.swift */,
+				16D6079329C1D41E00492879 /* ContentRestrictionsProvider.swift */,
 			);
 			path = Presenter;
 			sourceTree = "<group>";
@@ -866,6 +875,14 @@
 				16B08258298BEFD800EB9061 /* SearchBuilder.swift */,
 			);
 			path = Builder;
+			sourceTree = "<group>";
+		};
+		16D6079529C1D99200492879 /* Notification.Name */ = {
+			isa = PBXGroup;
+			children = (
+				16D6079629C1D9BF00492879 /* Notification.Name.swift */,
+			);
+			path = Notification.Name;
 			sourceTree = "<group>";
 		};
 		3A05E28A297D5FBB00987CFF /* Builder */ = {
@@ -1649,6 +1666,8 @@
 				1634B67429A93E14004A4B02 /* UserRatesState.swift in Sources */,
 				0010CADF29784E3C00F8705B /* Constants.swift in Sources */,
 				006031B7297BCA6800CD9A16 /* SearchViewController.swift in Sources */,
+				16D6079729C1D9BF00492879 /* Notification.Name.swift in Sources */,
+				16D6079929C21E7400492879 /* RestrictionsProvider.swift in Sources */,
 				16082BED29A26E1300450D43 /* GenresRequestsFactory.swift in Sources */,
 				006240F32997AF7C00498D51 /* UIApplication+Extensions.swift in Sources */,
 				00AFC6DD29A292580000B645 /* UserRatesTableViewCell.swift in Sources */,
@@ -1693,6 +1712,7 @@
 				3A8F30EA2974395F00F24DF7 /* ShikiApp.xcdatamodeld in Sources */,
 				16F98B5729AA808A009ADBA0 /* Date+relativeYear.swift in Sources */,
 				3A7E4D8B2985492C00E7CA17 /* MangaRatesResponseDTO.swift in Sources */,
+				16D6079429C1D41E00492879 /* ContentRestrictionsProvider.swift in Sources */,
 				BA90AF7D29A006B400CCE141 /* SearchDetailBuilder.swift in Sources */,
 				3A7E4D8F2985492C00E7CA17 /* UserProfileDTO.swift in Sources */,
 				16130E5829873BEF00A4EC94 /* AnimeListFilters.swift in Sources */,

--- a/ShikiApp/App/BusinessLogic/Network/AbstractRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/AbstractRequestFactory.swift
@@ -37,7 +37,7 @@ class AbstractRequestFactory<API: EndPointType>: AbstractRequestFactoryProtocol 
         router = Router<API>()
     }
 
-    // MARK: - Funcions
+    // MARK: - Functions
 
     func getResponse<Response: Codable>(
         type: Response.Type,

--- a/ShikiApp/App/BusinessLogic/Network/Animes/AnimesRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Animes/AnimesRequestFactory.swift
@@ -17,7 +17,7 @@ protocol AnimesRequestFactoryProtocol {
 
     // MARK: - Functions
 
-    func getAnimes(page: Int?, limit: Int?, filters: AnimeListFilters?, myList: [UserRatesStatus]?, search: String?, order: OrderBy?, completion: @escaping (_ response: AnimesResponseDTO?, _ error: String?) -> Void)
+    func getAnimes(page: Int?, limit: Int?, filters: AnimeListFilters?, myList: [UserRatesStatus]?, search: String?, censored: Bool?, order: OrderBy?, completion: @escaping (_ response: AnimesResponseDTO?, _ error: String?) -> Void)
 
     func getAnimeById(id: Int, completion: @escaping (_ response: AnimeDetailsDTO?, _ error: String?) -> Void)
 }
@@ -33,6 +33,7 @@ extension AnimesRequestFactoryProtocol {
                    filters: AnimeListFilters? = nil,
                    myList: [UserRatesStatus]? = nil,
                    search: String? = nil,
+                   censored: Bool? = true,
                    order: OrderBy? = nil,
                    completion: @escaping (_ response: AnimesResponseDTO?, _ error: String?) -> Void) {
         let parameters = validateAnimeListParameters(
@@ -41,6 +42,7 @@ extension AnimesRequestFactoryProtocol {
             filters: filters,
             myList: myList,
             search: search,
+            censored: censored,
             order: order
         )
         delegate?.getResponse(
@@ -56,7 +58,7 @@ extension AnimesRequestFactoryProtocol {
 
     // MARK: - Private functions
 
-    private func validateAnimeListParameters(page: Int?, limit: Int?, filters: AnimeListFilters?, myList: [UserRatesStatus]?, search: String?, order: OrderBy?) -> Parameters {
+    private func validateAnimeListParameters(page: Int?, limit: Int?, filters: AnimeListFilters?, myList: [UserRatesStatus]?, search: String?, censored: Bool?, order: OrderBy?) -> Parameters {
         var parameters = Parameters()
         if let page,
            (1 ... APIRestrictions.maxPages.rawValue).contains(page) {
@@ -70,6 +72,9 @@ extension AnimesRequestFactoryProtocol {
         }
         if let search {
             parameters[APIKeys.search.rawValue] = search
+        }
+        if let censored {
+            parameters[APIKeys.censored.rawValue] = censored
         }
         if let order {
             parameters[APIKeys.order.rawValue] = order.rawValue

--- a/ShikiApp/App/BusinessLogic/Network/AuthManager.swift
+++ b/ShikiApp/App/BusinessLogic/Network/AuthManager.swift
@@ -39,7 +39,13 @@ final class AuthManager: AuthManagerProtocol {
             scopes: ["user_rates", "comments", "topics"]
         )
     }()
-    private var credential: OAuth2Credential?
+    private var credential: OAuth2Credential? {
+        didSet {
+            if credential != oldValue {
+                NotificationCenter.default.post(name: .credentialsChanged, object: nil)
+            }
+        }
+    }
 
     // MARK: - Construction
     

--- a/ShikiApp/App/BusinessLogic/Network/Mangas/MangaListFilters.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Mangas/MangaListFilters.swift
@@ -19,13 +19,14 @@ struct ListFilters<K, S> {
     var season: String?
     var score: Int?
     var genre: [Int]?
-    lazy var filtersCount: Int = {
+    
+    func filtersCount() -> Int {
         var counter = 0
-        if let kind { counter += 1 }
-        if let status { counter += 1 }
-        if let score { counter += 1 }
+        if kind != nil { counter += 1 }
+        if status != nil { counter += 1 }
+        if score != nil { counter += 1 }
         if let genre { counter += genre.count }
         if let season { counter += 1 + season.filter {$0 == Constants.FilterParameters.delimiter}.count }
         return counter
-    }()
+    }
 }

--- a/ShikiApp/App/BusinessLogic/Network/Mangas/MangaListFilters.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Mangas/MangaListFilters.swift
@@ -13,13 +13,17 @@ import Foundation
 typealias MangaListFilters = ListFilters<MangaContentKind, MangaContentStatus>
 
 struct ListFilters<K, S> {
-    
+
+    // MARK: - Properties
+
     var kind: K?
     var status: S?
     var season: String?
     var score: Int?
     var genre: [Int]?
-    
+
+    // MARK: - Functions
+
     func filtersCount() -> Int {
         var counter = 0
         if kind != nil { counter += 1 }

--- a/ShikiApp/App/BusinessLogic/Network/Mangas/MangasRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Mangas/MangasRequestFactory.swift
@@ -17,7 +17,7 @@ protocol MangasRequestFactoryProtocol {
 
     // MARK: - Functions
 
-    func getMangas(page: Int?, limit: Int?, filters: MangaListFilters?, myList: [UserRatesStatus]?, search: String?, order: OrderBy?, completion: @escaping (_ response: MangaResponseDTO?, _ error: String?) -> Void)
+    func getMangas(page: Int?, limit: Int?, filters: MangaListFilters?, myList: [UserRatesStatus]?, search: String?, censored: Bool?, order: OrderBy?, completion: @escaping (_ response: MangaResponseDTO?, _ error: String?) -> Void)
 
     func getMangaById(id: Int, completion: @escaping (_ response: MangaDetailsDTO?, _ error: String?) -> Void)
 }
@@ -33,6 +33,7 @@ extension MangasRequestFactoryProtocol {
                    filters: MangaListFilters? = nil,
                    myList: [UserRatesStatus]? = nil,
                    search: String? = nil,
+                   censored: Bool? = true,
                    order: OrderBy? = nil,
                    completion: @escaping (_ response: MangaResponseDTO?, _ error: String?) -> Void) {
         
@@ -42,6 +43,7 @@ extension MangasRequestFactoryProtocol {
             filters: filters,
             myList: myList,
             search: search,
+            censored: censored,
             order: order
         )
         delegate?.getResponse(
@@ -57,7 +59,7 @@ extension MangasRequestFactoryProtocol {
 
     // MARK: - Private functions
 
-    private func validateListParameters(page: Int?, limit: Int?, filters: MangaListFilters?, myList: [UserRatesStatus]?, search: String?, order: OrderBy?) -> Parameters {
+    private func validateListParameters(page: Int?, limit: Int?, filters: MangaListFilters?, myList: [UserRatesStatus]?, search: String?, censored: Bool?, order: OrderBy?) -> Parameters {
         var parameters = Parameters()
         if let page,
            (1 ... APIRestrictions.maxPages.rawValue).contains(page) {
@@ -71,6 +73,9 @@ extension MangasRequestFactoryProtocol {
         }
         if let search {
             parameters[APIKeys.search.rawValue] = search
+        }
+        if let censored {
+            parameters[APIKeys.censored.rawValue] = censored
         }
         if let order {
             parameters[APIKeys.order.rawValue] = order.rawValue

--- a/ShikiApp/App/BusinessLogic/Network/Ranobes/RanobeRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Ranobes/RanobeRequestFactory.swift
@@ -17,7 +17,7 @@ protocol RanobeRequestFactoryProtocol {
 
     // MARK: - Functions
 
-    func getRanobes(page: Int?, limit: Int?, filters: RanobeListFilters?, search: String?, order: OrderBy?, completion: @escaping (_ response: RanobeResponseDTO?, _ error: String?) -> Void)
+    func getRanobes(page: Int?, limit: Int?, filters: RanobeListFilters?, search: String?, censored: Bool?, order: OrderBy?, completion: @escaping (_ response: RanobeResponseDTO?, _ error: String?) -> Void)
 
     func getRanobeById(id: Int, completion: @escaping (_ response: RanobeDetailsDTO?, _ error: String?) -> Void)
 }
@@ -33,6 +33,7 @@ extension RanobeRequestFactoryProtocol {
         limit: Int? = nil,
         filters: RanobeListFilters? = nil,
         search: String? = nil,
+        censored: Bool? = true,
         order: OrderBy? = nil,
         completion: @escaping (_ response: RanobeResponseDTO?, _ error: String?) -> Void
     ) {
@@ -41,6 +42,7 @@ extension RanobeRequestFactoryProtocol {
             limit: limit,
             filters: filters,
             search: search,
+            censored: censored,
             order: order
         )
         delegate?.getResponse(
@@ -56,22 +58,25 @@ extension RanobeRequestFactoryProtocol {
 
     // MARK: - Private functions
 
-    private func validateListParameters(page: Int?, limit: Int?, filters: RanobeListFilters?, search: String?, order: OrderBy?) -> Parameters {
+    private func validateListParameters(page: Int?, limit: Int?, filters: RanobeListFilters?, search: String?, censored: Bool?, order: OrderBy?) -> Parameters {
         var parameters = Parameters()
-        if let page = page,
+        if let page,
            (1 ... APIRestrictions.maxPages.rawValue).contains(page) {
             parameters[APIKeys.page.rawValue] = page
         }
-        if let limit = limit,
+        if let limit,
            (1 ... APIRestrictions.limit50.rawValue).contains(limit) { parameters[APIKeys.limit.rawValue] = limit
         }
-        if let search = search {
+        if let search {
             parameters[APIKeys.search.rawValue] = search
         }
-        if let order = order {
+        if let censored {
+            parameters[APIKeys.censored.rawValue] = censored
+        }
+        if let order {
             parameters[APIKeys.order.rawValue] = order.rawValue
         }
-        if let filters = filters {
+        if let filters {
             parameters.merge(validateListFilters(filters: filters)) { _, new in new }
         }
         return parameters

--- a/ShikiApp/App/Entity/Filters/FilterListModel.swift
+++ b/ShikiApp/App/Entity/Filters/FilterListModel.swift
@@ -40,20 +40,7 @@ final class FilterListModelFactory {
 
     // MARK: - Private properties
 
-    private var genresDictionary: [SearchContentEnum: [GenreModel]] = [:]
-
-    // MARK: - Constructions
-
-    init() {
-        if genresDictionary.isEmpty {
-            ApiFactory.makeGenresApi().getList { data, _ in
-                let factory = GenreModelFactory()
-                self.genresDictionary[.anime] = factory.build(genres: data, layer: .anime)
-                self.genresDictionary[.manga] = factory.build(genres: data, layer: .manga)
-                self.genresDictionary[.ranobe] = factory.build(genres: data, layer: .ranobe)
-            }
-        }
-    }
+    private let restrictionsProvider = RestrictionsProvider()
 
     // MARK: - Functions
 
@@ -133,14 +120,7 @@ final class FilterListModelFactory {
     }
 
     private func processGenres(layer: SearchContentEnum, genres: [Int]?) -> String {
-        var genresString = ""
-        guard let genres, let genresList = genresDictionary[layer] else { return genresString }
-        for genre in genres {
-            if let name = genresList.first(where: { $0.id == genre })?.name {
-                genresString += "\(name),"
-            }
-        }
-        return String(genresString.dropLast())
+        return restrictionsProvider.filterGenres(layer: layer, genres: genres)
     }
 
     private func processScore(score: Int?) -> String {

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/AnimeProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/AnimeProvider.swift
@@ -16,11 +16,17 @@ final class AnimeProvider: ContentProviderProtocol {
 
     // MARK: - Private properties
     
-    private let factory = ApiFactory.makeAnimesApi()
+    private let factory: AnimesRequestFactoryProtocol
 
     // MARK: - Properties
 
     var filters: AnimeListFilters?
+
+    // MARK: - Constructions
+
+    init() {
+        factory = ApiFactory.makeAnimesApi()
+    }
 
     // MARK: - Functions
 
@@ -41,6 +47,7 @@ final class AnimeProvider: ContentProviderProtocol {
             limit: APIRestrictions.limit50.rawValue,
             filters: filters,
             search: searchString,
+            censored: RestrictionsProvider.restrictions.isCensored(),
             order: .byRank,
             completion: completion
         )

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/AnimeProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/AnimeProvider.swift
@@ -30,13 +30,20 @@ final class AnimeProvider: ContentProviderProtocol {
 
     // MARK: - Functions
 
+    func getGenres() -> [Int]? { filters?.genre }
+    
+    func setGenres(genres: [Int]?) {
+        if filters == nil { filters = AnimeListFilters() }
+        filters?.genre = genres
+    }
+    
     func setFilters(filters: Any?) -> Int {
         self.filters = filters as? AnimeListFilters
-        return self.filters?.filtersCount ?? 0
+        return self.filters?.filtersCount() ?? 0
     }
 
     func getFiltersCounter() -> Int {
-        return self.filters?.filtersCount ?? 0
+        return self.filters?.filtersCount() ?? 0
     }
     
     func getFilters() -> Any? { filters }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentProviderProtocol.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentProviderProtocol.swift
@@ -23,6 +23,8 @@ protocol ContentProviderProtocol {
     func setFilters(filters: Any?) -> Int
     func getFiltersCounter() -> Int
     func getFilters() -> Any?
+    func getGenres() -> [Int]?
+    func setGenres(genres: [Int]?)
     func fetchData(searchString: String?, page: Int, completion: @escaping (_ response: [SearchContentProtocol]?, _ error: String?) -> Void )
     func fetchDetailData(id: Int, completion: @escaping (
         _ response: SearchDetailContentProtocol?,

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
@@ -74,14 +74,18 @@ final class ContentRestrictionsProvider: ContentRestrictionsProviderProtocol {
     }
 
     private func setCensoredValue() {
-        isActual = false
-        userFactory.whoAmI { [weak self] user, _ in
-            if let user {
-                self?.censored = user.fullYears ?? 0 < Constants.CensoredParameters.uncensoredAge
-            } else {
-                self?.censored = true
+        if AuthManager.share.isAuth() {
+            isActual = false
+            userFactory.whoAmI { [weak self] user, _ in
+                if let user {
+                    self?.censored = user.fullYears ?? 0 < Constants.CensoredParameters.uncensoredAge
+                } else {
+                    self?.censored = true
+                }
+                self?.isActual = true
             }
-            self?.isActual = true
+        } else {
+            censored = true
         }
     }
 }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
@@ -81,7 +81,7 @@ final class ContentRestrictionsProvider: ContentRestrictionsProviderProtocol {
             } else {
                 self?.censored = true
             }
-            self?.isActual.toggle()
+            self?.isActual = true
         }
     }
 }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
@@ -56,6 +56,7 @@ final class ContentRestrictionsProvider: ContentRestrictionsProviderProtocol {
     // MARK: - Functions
 
     func isCensored() -> Bool {
+        if isActual { return censored }
         let date = Date(timeIntervalSinceNow: Constants.Timeouts.networkRequest)
         repeat {
             if isActual { return censored }
@@ -85,6 +86,7 @@ final class ContentRestrictionsProvider: ContentRestrictionsProviderProtocol {
                 self?.isActual = true
             }
         } else {
+            isActual = true
             censored = true
         }
     }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/ContentRestrictionsProvider.swift
@@ -1,0 +1,74 @@
+//
+//  ContentRestrictionsProvider.swift
+//  ShikiApp
+//
+//  Created by Алексей Шинкарев on 15.03.2023.
+//
+
+import UIKit
+
+// MARK: - ContentRestrictionsProviderProtocol
+
+protocol ContentRestrictionsProviderProtocol {
+    
+    func isCensored() -> Bool
+}
+
+// MARK: - ContentRestrictionsProvider
+
+final class ContentRestrictionsProvider: ContentRestrictionsProviderProtocol {
+
+    // MARK: - Private properties
+
+    private var notificationCenter = NotificationCenter.default
+    private var censored = true
+    private var isActual = false
+    private let userFactory: UsersRequestFactoryProtocol
+
+    // MARK: - Constructions
+
+    init() {
+        userFactory = UsersRequestFactory()
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(onChangeCredentials(_:)),
+            name: .credentialsChanged,
+            object: nil
+        )
+        setCensoredValue()
+    }
+
+    // MARK: - Destructions
+
+    deinit {
+        notificationCenter.removeObserver(self, name: .credentialsChanged, object: nil)
+    }
+
+    // MARK: - Functions
+
+    func isCensored() -> Bool {
+        let date = Date(timeIntervalSinceNow: Constants.Timeouts.networkRequest)
+        repeat {
+            if isActual { return censored }
+        } while Date() < date
+        return true
+    }
+
+    // MARK: - Private functions
+
+    @objc private func onChangeCredentials(_ notification: Notification) {
+        setCensoredValue()
+    }
+    
+    private func setCensoredValue() {
+        isActual = false
+        userFactory.whoAmI { [weak self] user, _ in
+            if let user {
+                self?.censored = user.fullYears ?? 0 < Constants.CensoredParameters.uncensoredAge
+            } else {
+                self?.censored = true
+            }
+            self?.isActual.toggle()
+        }
+    }
+}

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/MangaProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/MangaProvider.swift
@@ -15,12 +15,18 @@ final class MangaProvider: ContentProviderProtocol {
     typealias ContentStatus = MangaContentStatus
 
     // MARK: - Private properties
-    
-    private let factory = ApiFactory.makeMangasApi()
+
+    private let factory: MangasRequestFactoryProtocol
 
     // MARK: - Properties
     
     var filters: MangaListFilters?
+
+    // MARK: - Constructions
+
+    init() {
+        factory = ApiFactory.makeMangasApi()
+    }
 
     // MARK: - Functions
 
@@ -41,6 +47,7 @@ final class MangaProvider: ContentProviderProtocol {
             limit: APIRestrictions.limit50.rawValue,
             filters: filters,
             search: searchString,
+            censored: RestrictionsProvider.restrictions.isCensored(),
             order: .byRank,
             completion: completion
         )

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/MangaProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/MangaProvider.swift
@@ -30,13 +30,20 @@ final class MangaProvider: ContentProviderProtocol {
 
     // MARK: - Functions
 
+    func getGenres() -> [Int]? { filters?.genre }
+    
+    func setGenres(genres: [Int]?) {
+        if filters == nil { filters = MangaListFilters() }
+        filters?.genre = genres
+    }
+
     func setFilters(filters: Any?) -> Int {
         self.filters = filters as? MangaListFilters
-        return self.filters?.filtersCount ?? 0
+        return self.filters?.filtersCount() ?? 0
     }
     
     func getFiltersCounter() -> Int {
-        return self.filters?.filtersCount ?? 0
+        return self.filters?.filtersCount() ?? 0
     }
     
     func getFilters() -> Any? { filters }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RanobeProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RanobeProvider.swift
@@ -30,13 +30,20 @@ final class RanobeProvider: ContentProviderProtocol {
 
     // MARK: - Functions
 
+    func getGenres() -> [Int]? { filters?.genre }
+    
+    func setGenres(genres: [Int]?) {
+        if filters == nil { filters = RanobeListFilters() }
+        filters?.genre = genres
+    }
+
     func setFilters(filters: Any?) -> Int {
         self.filters = filters as? RanobeListFilters
-        return self.filters?.filtersCount ?? 0
+        return self.filters?.filtersCount() ?? 0
     }
     
     func getFiltersCounter() -> Int {
-        return self.filters?.filtersCount ?? 0
+        return self.filters?.filtersCount() ?? 0
     }
     
     func getFilters() -> Any? { filters }

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RanobeProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RanobeProvider.swift
@@ -16,11 +16,17 @@ final class RanobeProvider: ContentProviderProtocol {
 
     // MARK: - Private properties
     
-    private let factory = ApiFactory.makeRanobeApi()
+    private let factory: RanobeRequestFactoryProtocol
 
     // MARK: - Properties
 
     var filters: RanobeListFilters?
+
+    // MARK: - Constructions
+
+    init() {
+        factory = ApiFactory.makeRanobeApi()
+    }
 
     // MARK: - Functions
 
@@ -41,6 +47,7 @@ final class RanobeProvider: ContentProviderProtocol {
             limit: APIRestrictions.limit50.rawValue,
             filters: filters,
             search: searchString,
+            censored: RestrictionsProvider.restrictions.isCensored(),
             order: .byRank,
             completion: completion
         )

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RestrictionsProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RestrictionsProvider.swift
@@ -1,0 +1,17 @@
+//
+//  RestrictionsProvider.swift
+//  ShikiApp
+//
+//  Created by Алексей Шинкарев on 15.03.2023.
+//
+
+import Foundation
+
+// MARK: - RestrictionsProvider
+
+final class RestrictionsProvider {
+
+    // MARK: - Properties
+
+    static var restrictions: ContentRestrictionsProviderProtocol = ContentRestrictionsProvider()
+}

--- a/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RestrictionsProvider.swift
+++ b/ShikiApp/App/Flows/Search/SearchResultsScreen/Presenter/RestrictionsProvider.swift
@@ -14,4 +14,76 @@ final class RestrictionsProvider {
     // MARK: - Properties
 
     static var restrictions: ContentRestrictionsProviderProtocol = ContentRestrictionsProvider()
+
+    // MARK: - Private properties
+
+    private static var censoredGenres: [SearchContentEnum: [Int]] = [:]
+    private static var genresDictionary: [SearchContentEnum: [GenreModel]] = [:]
+
+    // MARK: - Constructions
+
+    init() {
+        if Self.genresDictionary.isEmpty {
+            ApiFactory.makeGenresApi().getList { data, _ in
+                let factory = GenreModelFactory()
+                let censored = Constants.censoredGenres.map { $0.lowercased() }
+                Self.genresDictionary[.anime] = factory.build(genres: data, layer: .anime)
+                Self.genresDictionary[.manga] = factory.build(genres: data, layer: .manga)
+                Self.genresDictionary[.ranobe] = factory.build(genres: data, layer: .ranobe)
+                let genres = data?.filter { censored.contains($0.name.lowercased()) }
+                Self.censoredGenres[.anime] = factory.build(genres: genres, layer: .anime).map { $0.id }
+                Self.censoredGenres[.manga] = factory.build(genres: genres, layer: .manga).map { $0.id }
+                Self.censoredGenres[.ranobe] = factory.build(genres: genres, layer: .ranobe).map { $0.id }
+            }
+        }
+    }
+    
+    static func addObserver(observer: @escaping (Bool) -> Void) {
+        restrictions.addObserver(observer: observer)
+    }
+    
+    func getGenres(layer: SearchContentEnum) -> [String] {
+        var genres = Self.genresDictionary[layer]
+        if Self.restrictions.isCensored(), let censored = Self.censoredGenres[layer] {
+            genres?.removeAll(where: {censored.contains($0.id)})
+        }
+        return genres?.map { $0.name } ?? []
+    }
+    
+    func filterGenres(layer: SearchContentEnum, genres: [Int]?) -> String {
+        
+        var genresString = ""
+        guard let genresList = Self.genresDictionary[layer], var censoredGenres = genres else { return genresString }
+        if Self.restrictions.isCensored(), let censored = Self.censoredGenres[layer] {
+            censoredGenres.removeAll(where: {censored.contains($0)})
+        }
+        for genre in censoredGenres {
+            if let name = genresList.first(where: { $0.id == genre })?.name {
+                genresString += "\(name),"
+            }
+        }
+        return String(genresString.dropLast())
+    }
+    
+    func filterGenres(layer: SearchContentEnum, genres: [Int]?) -> [Int]? {
+        guard var censoredGenres = genres else { return nil }
+        if let censored = Self.censoredGenres[layer] {
+            censoredGenres.removeAll(where: {censored.contains($0)})
+        }
+        return censoredGenres
+    }
+    func filterGenres(layer: SearchContentEnum, genres: String) -> [Int]? {
+        if genres.isEmpty { return nil }
+        var genresArray = [Int]()
+        let genresList = genres.split(separator: ",")
+        for element in genresList {
+            if let genreId = Self.genresDictionary[layer]?.first(where: {$0.name == element})?.id {
+                genresArray.append(genreId)
+            }
+        }
+        if Self.restrictions.isCensored(), let censored = Self.censoredGenres[layer] {
+            genresArray.removeAll(where: {censored.contains($0)})
+        }
+        return genresArray
+    }
 }

--- a/ShikiApp/Core/Extensions/Notification.Name/Notification.Name.swift
+++ b/ShikiApp/Core/Extensions/Notification.Name/Notification.Name.swift
@@ -1,0 +1,15 @@
+//
+//  Notification.Name.swift
+//  ShikiApp
+//
+//  Created by Алексей Шинкарев on 15.03.2023.
+//
+
+import Foundation
+
+extension Notification.Name {
+
+    static var credentialsChanged: Notification.Name {
+        return .init(rawValue: "Credentials.changed")
+    }
+}

--- a/ShikiApp/Core/Network/OAuth2Credential.swift
+++ b/ShikiApp/Core/Network/OAuth2Credential.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct OAuth2Credential: Codable {
+struct OAuth2Credential: Codable, Equatable {
     
     let accessToken: String
     let tokenType: String?

--- a/ShikiApp/Resources/Constants.swift
+++ b/ShikiApp/Resources/Constants.swift
@@ -65,8 +65,15 @@ struct Constants {
         static let startYearForFilter = 1917
     }
     
+    enum Timeouts {
+        static let networkRequest = 15.0
+    }
     enum FilterParameters {
         static let delimiter: Character = ","
+    }
+    
+    enum CensoredParameters {
+        static let uncensoredAge = 18
     }
     
     enum SearchHeader {
@@ -152,11 +159,13 @@ struct Constants {
         "discontinued": "Прекращено",
         "anons": "Анонсировано"
     ]
+    
     static let animeStatuses = [
         "ongoing": "Онгоинг",
         "released": "Вышло",
         "anons": "Анонсировано"
     ]
+    
     static let rating = [
         "r": "R",
         "pg": "PG",
@@ -165,4 +174,8 @@ struct Constants {
         "rx": "RX",
         "none": ""
     ]
+    
+    enum NotificationKeys: String {
+        case authState
+    }
 }

--- a/ShikiApp/Resources/Constants.swift
+++ b/ShikiApp/Resources/Constants.swift
@@ -178,4 +178,6 @@ struct Constants {
     enum NotificationKeys: String {
         case authState
     }
+    
+    static let censoredGenres = ["hentai", "yaoi", "yuri"]
 }


### PR DESCRIPTION
В движок получения списков аниме/манга/ранобе добавил параметр "censored", фильтрующий контент hentai, yaoi and yuri в случае значения true (если описание API нас не вводит в заблуждение)
Логика формирования такая: 
true: 
- если пользователь не залогинен 
- залогинен, но у него в профиле не заполнено поле fullYears
- залогинен, и у него в профиле fullYears<18
- не удалось получить ответ от метода whoAmI  за время таймаута (15сек)

false: в противном случае

поскольку censored = true игнорируется при явном указании жанра из категории 18+, добавил фильтрацию 18+ для списка жанров и ранее выбранных жанров при логине/логауте (когда censored выставляется в true)
начитанный контент из категории 18+ при этом не вычищаю из результатов поиска чтобы не превысить лимит запросов (контент обновится после первого же изменения критериев поиска)