### PR TITLE
Feature/SA-91 Change user rates reading

### DIFF
--- a/ShikiApp.xcodeproj/project.pbxproj
+++ b/ShikiApp.xcodeproj/project.pbxproj
@@ -334,10 +334,10 @@
 		16D49EA6298EF3540008CAA4 /* MangaProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MangaProvider.swift; sourceTree = "<group>"; };
 		16D49EA8298EF5660008CAA4 /* RanobeProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RanobeProvider.swift; sourceTree = "<group>"; };
 		16D49EAA298FC6260008CAA4 /* SearchTableCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchTableCell.swift; sourceTree = "<group>"; };
-		16DBE56F29B9F717001AEFBB /* UserDefaultsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsService.swift; sourceTree = "<group>"; };
 		16D6079329C1D41E00492879 /* ContentRestrictionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentRestrictionsProvider.swift; sourceTree = "<group>"; };
 		16D6079629C1D9BF00492879 /* Notification.Name.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Notification.Name.swift; sourceTree = "<group>"; };
 		16D6079829C21E7400492879 /* RestrictionsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestrictionsProvider.swift; sourceTree = "<group>"; };
+		16DBE56F29B9F717001AEFBB /* UserDefaultsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsService.swift; sourceTree = "<group>"; };
 		16F98B5629AA808A009ADBA0 /* Date+relativeYear.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+relativeYear.swift"; sourceTree = "<group>"; };
 		3A05E290297D606B00987CFF /* NewsfeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedViewController.swift; sourceTree = "<group>"; };
 		3A05E292297D60B100987CFF /* NewsfeedTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewsfeedTableViewCell.swift; sourceTree = "<group>"; };
@@ -888,20 +888,20 @@
 			path = Builder;
 			sourceTree = "<group>";
 		};
-		16DBE56E29B9F6E3001AEFBB /* UserDefaultsService */ = {
-            isa = PBXGroup;
-            children = (
-				16DBE56F29B9F717001AEFBB /* UserDefaultsService.swift */,
-            );
-			path = UserDefaultsService;
-            sourceTree = "<group>";
-        };
 		16D6079529C1D99200492879 /* Notification.Name */ = {
 			isa = PBXGroup;
 			children = (
 				16D6079629C1D9BF00492879 /* Notification.Name.swift */,
 			);
 			path = Notification.Name;
+			sourceTree = "<group>";
+		};
+		16DBE56E29B9F6E3001AEFBB /* UserDefaultsService */ = {
+			isa = PBXGroup;
+			children = (
+				16DBE56F29B9F717001AEFBB /* UserDefaultsService.swift */,
+			);
+			path = UserDefaultsService;
 			sourceTree = "<group>";
 		};
 		3A05E28A297D5FBB00987CFF /* Builder */ = {

--- a/ShikiApp/App/BusinessLogic/Network/Ranobes/RanobeRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Ranobes/RanobeRequestFactory.swift
@@ -17,7 +17,7 @@ protocol RanobeRequestFactoryProtocol {
 
     // MARK: - Functions
 
-    func getRanobes(page: Int?, limit: Int?, filters: RanobeListFilters?, search: String?, censored: Bool?, order: OrderBy?, completion: @escaping (_ response: RanobeResponseDTO?, _ error: String?) -> Void)
+    func getRanobes(page: Int?, limit: Int?, filters: RanobeListFilters?, myList: [UserRatesStatus]?, search: String?, censored: Bool?, order: OrderBy?, completion: @escaping (_ response: RanobeResponseDTO?, _ error: String?) -> Void)
 
     func getRanobeById(id: Int, completion: @escaping (_ response: RanobeDetailsDTO?, _ error: String?) -> Void)
 }
@@ -32,6 +32,7 @@ extension RanobeRequestFactoryProtocol {
         page: Int? = nil,
         limit: Int? = nil,
         filters: RanobeListFilters? = nil,
+        myList: [UserRatesStatus]? = nil,
         search: String? = nil,
         censored: Bool? = true,
         order: OrderBy? = nil,
@@ -41,6 +42,7 @@ extension RanobeRequestFactoryProtocol {
             page: page,
             limit: limit,
             filters: filters,
+            myList: myList,
             search: search,
             censored: censored,
             order: order
@@ -58,7 +60,15 @@ extension RanobeRequestFactoryProtocol {
 
     // MARK: - Private functions
 
-    private func validateListParameters(page: Int?, limit: Int?, filters: RanobeListFilters?, search: String?, censored: Bool?, order: OrderBy?) -> Parameters {
+    private func validateListParameters(
+        page: Int?,
+        limit: Int?,
+        filters: RanobeListFilters?,
+        myList: [UserRatesStatus]?,
+        search: String?,
+        censored: Bool?,
+        order: OrderBy?
+    ) -> Parameters {
         var parameters = Parameters()
         if let page,
            (1 ... APIRestrictions.maxPages.rawValue).contains(page) {
@@ -66,6 +76,9 @@ extension RanobeRequestFactoryProtocol {
         }
         if let limit,
            (1 ... APIRestrictions.limit50.rawValue).contains(limit) { parameters[APIKeys.limit.rawValue] = limit
+        }
+        if let myList {
+            parameters[APIKeys.myList.rawValue] = myList.map {$0.rawValue}.joined(separator: ",")
         }
         if let search {
             parameters[APIKeys.search.rawValue] = search

--- a/ShikiApp/App/BusinessLogic/Network/Users/UsersRequestFactory.swift
+++ b/ShikiApp/App/BusinessLogic/Network/Users/UsersRequestFactory.swift
@@ -35,7 +35,7 @@ protocol UsersRequestFactoryProtocol {
     
     func getAnimeRates(id: Int, page: Int?, limit: Int?, status: UserContentState?, isCensored: Bool?, completion: @escaping (_ response: AnimeRatesResponseDTO?, _ error: String?) -> Void)
     
-    func getMangaRates(id: Int, page: Int?, limit: Int?, isCensored: Bool?, completion: @escaping (_ response: MangaRatesResponseDTO?, _ error: String?) -> Void)
+    func getMangaRates(id: Int, page: Int?, limit: Int?, status: UserContentState?, isCensored: Bool?, completion: @escaping (_ response: MangaRatesResponseDTO?, _ error: String?) -> Void)
     
     func getFavorites(id: Int, completion: @escaping (_ response: UserFavoritesResponseDTO?, _ error: String?) -> Void)
     
@@ -135,49 +135,29 @@ extension UsersRequestFactoryProtocol {
         )
         return
 
-        func validateParameters(page: Int?,
-                                limit: Int?,
-                                status: UserContentState?,
-                                isCensored: Bool?) -> Parameters {
-            var parameters = Parameters()
-            if let page = page,
-               (1 ... APIRestrictions.maxPages.rawValue).contains(page) {
-                parameters[APIKeys.page.rawValue] = page
-            }
-            if let limit = limit,
-               (1 ... APIRestrictions.limit5000.rawValue).contains(limit) { parameters[APIKeys.limit.rawValue] = limit
-            }
-            if let status = status { parameters[APIKeys.status.rawValue] = status.rawValue }
-            if let isCensored = isCensored { parameters[APIKeys.censored.rawValue] = isCensored }
-            return parameters
-        }
     }
 
     func getMangaRates(id: Int,
                        page: Int? = nil,
                        limit: Int? = nil,
+                       status: UserContentState?,
                        isCensored: Bool?,
                        completion: @escaping (_ response: MangaRatesResponseDTO?, _ error: String?) -> Void) {
-        let parameters = validateParameters(page: page, limit: limit, isCensored: isCensored)
         delegate?.getResponse(
             type: MangaRatesResponseDTO.self,
-            endPoint: .listMangaRates(id: id, parameters: parameters),
+            endPoint: .listMangaRates(
+                id: id,
+                parameters: validateParameters(
+                    page: page,
+                    limit: limit,
+                    status: status,
+                    isCensored: isCensored
+                )
+            ),
             completion: completion
         )
         return
 
-        func validateParameters(page: Int?, limit: Int?, isCensored: Bool?) -> Parameters {
-            var parameters = Parameters()
-            if let page = page,
-               (1 ... APIRestrictions.maxPages.rawValue).contains(page) {
-                parameters[APIKeys.page.rawValue] = page
-            }
-            if let limit = limit,
-               (1 ... APIRestrictions.limit5000.rawValue).contains(limit) { parameters[APIKeys.limit.rawValue] = limit
-            }
-            if let isCensored = isCensored { parameters[APIKeys.censored.rawValue] = isCensored }
-            return parameters
-        }
     }
 
     func getFavorites(id: Int,
@@ -257,6 +237,27 @@ extension UsersRequestFactoryProtocol {
 
     func getBans(id: Int, completion: @escaping (_ response: BansResponseDTO?, _ error: String?) -> Void) {
         delegate?.getResponse(type: BansResponseDTO.self, endPoint: .listBans(id: id), completion: completion)
+    }
+
+    // MARK: - Private functions
+
+    private func validateParameters(
+                            page: Int?,
+                            limit: Int?,
+                            status: UserContentState?,
+                            isCensored: Bool?
+    ) -> Parameters {
+        var parameters = Parameters()
+        if let page,
+           (1 ... APIRestrictions.maxPages.rawValue).contains(page) {
+            parameters[APIKeys.page.rawValue] = page
+        }
+        if let limit,
+           (1 ... APIRestrictions.limit5000.rawValue).contains(limit) { parameters[APIKeys.limit.rawValue] = limit
+        }
+        if let status { parameters[APIKeys.status.rawValue] = status.rawValue }
+        if let isCensored { parameters[APIKeys.censored.rawValue] = isCensored }
+        return parameters
     }
 }
 

--- a/ShikiApp/App/Flows/UserRates/Presenter/UserRatesPresenter.swift
+++ b/ShikiApp/App/Flows/UserRates/Presenter/UserRatesPresenter.swift
@@ -39,8 +39,6 @@ final class UserRatesPresenter: UserRatesViewOutput {
     
     private let userRatesApiFactory = ApiFactory.makeUserRatesApi()
     private let usersApiFactory = ApiFactory.makeUsersApi()
-    private let animesApiFactory = ApiFactory.makeAnimesApi()
-    private let mangasApiFactory = ApiFactory.makeMangasApi()
     private let modelFactory = UserRatesModelFactory()
     
     var targetType: UserRatesTargetType = .anime
@@ -78,6 +76,7 @@ final class UserRatesPresenter: UserRatesViewOutput {
                         
                         self.requestCount += 2
                         self.getDetails(
+                            userId: userId,
                             targetType: targetType,
                             status: status,
                             pageCount: self.getPageCount(ratesList: self.ratesList)
@@ -96,20 +95,22 @@ final class UserRatesPresenter: UserRatesViewOutput {
     // MARK: - Private functions
 
     private func getListAnimesFromMyList(
-        status: [UserRatesStatus],
+        userId: Int,
+        status: UserRatesStatus?,
         page: Int,
         limit: Int
     ) {
-        animesApiFactory.getAnimes(
+        usersApiFactory.getAnimeRates(
+            id: userId,
             page: page,
             limit: limit,
-            myList: status,
-            order: .byPopularity
+            status: status,
+            isCensored: nil
         ) { [weak self] data, errorMessage in
             guard let self,
                   let data else { return }
             
-            self.contentResponse = data
+            self.contentResponse = data.map { $0.anime }
             self.error = errorMessage ?? ""
             print("ERROR: \(self.error), PAGE: \(page)")
             self.contentDetailList.append(contentsOf: self.contentResponse)
@@ -119,20 +120,22 @@ final class UserRatesPresenter: UserRatesViewOutput {
     }
     
     private func getListMangasFromMyList(
-        status: [UserRatesStatus],
+        userId: Int,
+        status: UserRatesStatus?,
         page: Int,
         limit: Int
     ) {
-        mangasApiFactory.getMangas(
+        usersApiFactory.getMangaRates(
+            id: userId,
             page: page,
             limit: limit,
-            myList: status,
-            order: .byPopularity
+            status: status,
+            isCensored: nil
         ) { [weak self] data, errorMessage in
             guard let self,
                   let data else { return }
             
-            self.contentResponse = data
+            self.contentResponse = data.map { $0.manga }
             self.error = errorMessage ?? ""
             print("ERROR: \(self.error), PAGE: \(page)") 
             self.contentDetailList.append(contentsOf: self.contentResponse)
@@ -141,18 +144,11 @@ final class UserRatesPresenter: UserRatesViewOutput {
         self.requestCount += 1
     }
     
-    private func getDetails(targetType: UserRatesTargetType, status: UserRatesStatus?, pageCount: Int) {
-        var statusForDetail: [UserRatesStatus] = []
+    private func getDetails(userId: Int, targetType: UserRatesTargetType, status: UserRatesStatus?, pageCount: Int) {
         contentDetailList.removeAll()
         
         guard pageCount != 0 else {
             return getContentDetailList(contentDetailList: contentDetailList, ratesList: ratesList)
-        }
-        
-        if status == nil {
-            statusForDetail = [.watching, .reWatching, .planned, .onHold, .dropped, .completed]
-        } else {
-            statusForDetail = [status ?? .watching]
         }
         
         for page in 1...pageCount {
@@ -161,9 +157,9 @@ final class UserRatesPresenter: UserRatesViewOutput {
             sleep(UInt32(timeIntervalPerSecond))
             switch targetType {
             case .anime:
-                self.getListAnimesFromMyList(status: statusForDetail, page: page, limit: itemsLimit)
+                self.getListAnimesFromMyList(userId: userId, status: status, page: page, limit: itemsLimit)
             case .manga:
-                self.getListMangasFromMyList(status: statusForDetail, page: page, limit: itemsLimit)
+                self.getListMangasFromMyList(userId: userId, status: status, page: page, limit: itemsLimit)
             }
         }
         self.requestCount = 0

--- a/ShikiApp/Environments/Base.xcconfig
+++ b/ShikiApp/Environments/Base.xcconfig
@@ -10,5 +10,5 @@
 
 #include "Secret.xcconfig"
 
-API_URL = https:/$()/shikimori.one/api/
-BASE_URL = https:/$()/shikimori.one
+API_URL = https:/$()/shikimori.me/api/
+BASE_URL = https:/$()/shikimori.me

--- a/ShikiApp/Resources/Constants.swift
+++ b/ShikiApp/Resources/Constants.swift
@@ -83,8 +83,7 @@ struct Constants {
     }
     
     enum LimitsForRequest {
-        
-        static let itemsLimit: Int = 50
+        static let itemsLimit: Int = 5000
         static let limitRequestsPerSecond: Int = 5
     }
 

--- a/ShikiAppTests/UsersApiTests.swift
+++ b/ShikiAppTests/UsersApiTests.swift
@@ -243,7 +243,7 @@ final class UsersApiTests: XCTestCase {
         factory.whoAmI { data, errorMessage in
             if let id = data?.id {
                 Timer.scheduledTimer(withTimeInterval: self.delayRequests, repeats: false) { _ in
-                    factory.getMangaRates(id: id, isCensored: true) { data, errorMessage in
+                    factory.getMangaRates(id: id, status: nil, isCensored: true) { data, errorMessage in
                         response = data
                         error = errorMessage
                         expectation.fulfill()


### PR DESCRIPTION
1 Поменял механизм чтения списков аниме и манга-ранобе в презентере списков пользователя:
 АПИ GET /api/animes на GET /api/users/:id/anime_rates
 АПИ GET /api/mangas на  GET /api/users/:id/manga_rates
В новом варианте лимит страницы 5000 записей вместо 50 и намного реже придется прибегать к задержке в 5сек чтобы не словить временный бан по превышению RPS.
2 Пофиксил мелкие недоработки в сетевом слое: Местами описание АПИ не включало все разрешенные параметры. Проверил что они реально работают, добавил
3. Сайт неожиданно переехал с shikimori.one на shikimori.me Поменял  BASE_URL  & API_URL